### PR TITLE
Fix `LSR.THRE` field

### DIFF
--- a/src/apb_uart.sv
+++ b/src/apb_uart.sv
@@ -124,7 +124,6 @@ reg iLSR_PE; // 612
 reg iLSR_FE; // 612
 reg iLSR_BI; // 612
 reg iLSR_THRE; // 612
-reg iLSR_THRNF; // 612
 reg iLSR_TEMT; // 612
 reg iLSR_FIFOERR; // 612
 reg iMSR_dCTS; // 612
@@ -523,14 +522,13 @@ assign     iLSR[1]         = iLSR_OE;
 assign     iLSR[2]         = iLSR_PE;
 assign     iLSR[3]         = iLSR_FE;
 assign     iLSR[4]         = iLSR_BI;
-assign     iLSR[5]         = iLSR_THRNF;
+assign     iLSR[5]         = iLSR_THRE;
 assign     iLSR[6]         = iLSR_TEMT;
 assign     iLSR[7]         = iFCR_FIFOEnable && iLSR_FIFOERR;
    
 assign /*903*/ iLSR_DR = iRXFIFOEmpty ==  1'b0 | iRXFIFOWrite ==  1'b1 ?  1'b1 :   1'b0; // 905
 assign /*903*/ iLSR_THRE = iTXFIFOEmpty ==  1'b1 ?  1'b1 :   1'b0; // 905
 assign /*903*/ iLSR_TEMT = iTXRunning ==  1'b0 && iLSR_THRE ==  1'b1 ?  1'b1 :   1'b0; // 905
-assign /*903*/ iLSR_THRNF = ((iFCR_FIFOEnable ==  1'b0 && iTXFIFOEmpty ==  1'b1) | (iFCR_FIFOEnable ==  1'b1 && iTXFIFOFull ==  1'b0)) ?  1'b1 :   1'b0; // 905
 assign /*903*/ iMSR_CTS = (iMCR_LOOP ==  1'b1 && iRTS ==  1'b1) | (iMCR_LOOP ==  1'b0 && iCTSn ==  1'b0) ?  1'b1 :   1'b0; // 905
 assign /*903*/ iMSR_DSR = (iMCR_LOOP ==  1'b1 && iMCR_DTR ==  1'b1) | (iMCR_LOOP ==  1'b0 && iDSRn ==  1'b0) ?  1'b1 :   1'b0; // 905
 assign /*903*/ iMSR_RI = (iMCR_LOOP ==  1'b1 && iMCR_OUT1 ==  1'b1) | (iMCR_LOOP ==  1'b0 && iRIn ==  1'b0) ?  1'b1 :   1'b0; // 905

--- a/src/vhdl_orig/apb_uart.vhd
+++ b/src/vhdl_orig/apb_uart.vhd
@@ -272,7 +272,6 @@ architecture rtl of apb_uart is
     signal iLSR_FE          : std_logic;                        -- LSR: Framing error
     signal iLSR_BI          : std_logic;                        -- LSR: Break Interrupt
     signal iLSR_THRE        : std_logic;                        -- LSR: Transmitter holding register empty
-    signal iLSR_THRNF       : std_logic;                        -- LSR: Transmitter holding register not full
     signal iLSR_TEMT        : std_logic;                        -- LSR: Transmitter empty
     signal iLSR_FIFOERR     : std_logic;                        -- LSR: Error in receiver FIFO
 
@@ -665,13 +664,12 @@ begin
     iLSR(2)         <= iLSR_PE;
     iLSR(3)         <= iLSR_FE;
     iLSR(4)         <= iLSR_BI;
-    iLSR(5)         <= iLSR_THRNF;
+    iLSR(5)         <= iLSR_THRE;
     iLSR(6)         <= iLSR_TEMT;
     iLSR(7)         <= '1' when iFCR_FIFOEnable = '1' and iLSR_FIFOERR = '1' else '0';
     iLSR_DR         <= '1' when iRXFIFOEmpty = '0' or iRXFIFOWrite = '1' else '0';
     iLSR_THRE       <= '1' when iTXFIFOEmpty = '1' else '0';
     iLSR_TEMT       <= '1' when iTXRunning = '0' and iLSR_THRE = '1' else '0';
-    iLSR_THRNF      <= '1' when ((iFCR_FIFOEnable = '0' and iTXFIFOEmpty = '1') or (iFCR_FIFOEnable = '1' and iTXFIFOFull = '0')) else '0';
 
     -- Modem status register
     iMSR_CTS <= '1' when (iMCR_LOOP = '1' and iRTS = '1')      or (iMCR_LOOP = '0' and iCTSn = '0') else '0';


### PR DESCRIPTION
The Transmit Holding Register Empty (THRE) field of the Line Status Register (LSR) was previously connected to the 'not full' signal of the transmit FIFO.

Refer to page 5 of the data sheet:
https://media.digikey.com/pdf/Data%20Sheets/Texas%20Instruments%20PDFs/PC16550D.pdf