### PR TITLE
Propagate AddrWidth parameter from top-level.

### DIFF
--- a/src/apb_uart_wrap.sv
+++ b/src/apb_uart_wrap.sv
@@ -9,6 +9,7 @@
 
 // A UART with APB struct ports.
 module apb_uart_wrap #(
+  parameter int  unsigned AddrWidth = -1,
   parameter type apb_req_t = logic,
   parameter type apb_rsp_t = logic
 ) (
@@ -34,7 +35,7 @@ module apb_uart_wrap #(
 );
 
   localparam obi_pkg::obi_cfg_t ObiCfg = obi_pkg::obi_default_cfg(
-      $bits(apb_req_i.paddr),
+      AddrWidth,
       32,
       1,
       obi_pkg::ObiMinimalOptionalConfig

--- a/src/reg_uart_wrap.sv
+++ b/src/reg_uart_wrap.sv
@@ -54,6 +54,7 @@ module reg_uart_wrap #(
   );
 
   apb_uart_wrap #(
+    .AddrWidth ( AddrWidth ),
     .apb_req_t ( apb_req_t ),
     .apb_rsp_t ( apb_resp_t )
   ) i_apb_uart_wrap (


### PR DESCRIPTION
**This PR is trying to "improve" cross-compatibility of our code among different vendor tools.**

Cadence Xcelium triggers an [OBI Address Width mismatch assertion](https://github.com/pulp-platform/obi/blob/main/src/obi_to_apb.sv#L164) due to the inability to properly infer the address size of a hierarchical struct using `$bits()`. This was tested within Cheshire: the [ObiCfg](https://github.com/pulp-platform/apb_uart/blob/main/src/apb_uart_wrap.sv#L36) parameter results in a 3-bits-wide address field, making the simulation with Xcelium stall on an infinite loop during the printf. It is a bit hard to understand why the simulator behaves this way since it does not trigger any warning at compile time apart from:
* W,BNDWRN (/path/to/cheshire/.bender/git/checkouts/obi_peripherals-9423aa14f6eba9a7/hw/obi_uart/obi_uart_register.sv,58|53): Bit-select or part-select index out of declared bounds.
    assert (AddrWidth != 0) else $fatal("AddrWidth must be non-zero!", 1);
    -> linked  to [this](https://github.com/pulp-platform/obi_peripherals/blob/main/hw/obi_uart/obi_uart_register.sv#L58), which I think is a direct consequence of the inability to properly infer the struct field size.

I see there was an [issue](https://github.com/verilator/verilator/issues/5133) open on Verilator related to a similar problem trying to (I suppose) close the behavioral gap between Verilator and propritary tools, including Xcelium in this case. In the [related discussion](https://github.com/renode/renode/issues/619) the people noticing this issue mention that using the `$bits()` when inferring hierarchical structs dimensions should actually solve compile warnings/errors in Xcelium, but what I experience is still a misehaviour during simulation.

Since the reg_uart_wrap.sv already provides an [AddrWidth](https://github.com/pulp-platform/apb_uart/blob/main/src/reg_uart_wrap.sv#L13) parameter, this PR simply proposes to forward such parameter to the apb_uart_wrap.sv as well, solving the issue during Cadence Xcelium simulation